### PR TITLE
fix(docs): format code expression string as code

### DIFF
--- a/docs/backend/8base-console-custom-functions-tasks.md
+++ b/docs/backend/8base-console-custom-functions-tasks.md
@@ -83,12 +83,12 @@ For a singular value (1) the unit must be written as singular, otherwise it need
 
 | Expression                   | Instruction                                                         |
 | :--------------------------- | :------------------------------------------------------------------ |
-| cron(0 10 * * ? *)           | Invoke task at 10:00am (UTC) everyday                               |
-| cron(15 12 * * ? *)          | Invoke task at 12:15pm (UTC) everyday                               |
-| cron(0 18 ? * MON-FRI *)     | Invoke task at 06:00pm (UTC) every Mon-Fri                          |
-| cron(0/10 * ? * MON-FRI *)   | Invoke task every 10 min Mon-Fri                                    |
-| cron(0/5 8-17 ? * MON-FRI *) | Invoke task every 5 minutes Mon-Fri between 8:00am and 5:55pm (UTC) |
-| cron(0 9 ? * 2#1 *)          | Invoke task at 9 a.m. (UTC) the first Monday of each month          |
+| `cron(0 10 * * ? *)`           | Invoke task at 10:00am (UTC) everyday                               |
+| `cron(15 12 * * ? *)`          | Invoke task at 12:15pm (UTC) everyday                               |
+| `cron(0 18 ? * MON-FRI *)`     | Invoke task at 06:00pm (UTC) every Mon-Fri                          |
+| `cron(0/10 * ? * MON-FRI *)`   | Invoke task every 10 min Mon-Fri                                    |
+| `cron(0/5 8-17 ? * MON-FRI *)` | Invoke task every 5 minutes Mon-Fri between 8:00am and 5:55pm (UTC) |
+| `cron(0 9 ? * 2#1 *)`          | Invoke task at 9 a.m. (UTC) the first Monday of each month          |
 
 Cron expressions that lead to rates faster than one invocation/minute are not supported. Additionally, one of the day-of-month or day-of-week values must be a question mark (?).
 


### PR DESCRIPTION
The cron expression preview is invalid, because the `*` symbol is formatting the other symbols with the emphasis tag. We need to wrap the cron expression with the code formatter.