### PR TITLE
fix: Changed heading to title case, fixed typo.

### DIFF
--- a/docs/projects/introduction/10-developer-resources.md
+++ b/docs/projects/introduction/10-developer-resources.md
@@ -5,7 +5,7 @@ slug: '/introduction/developer-resources'
 ---
 # Developer Resources
 
-## 8base resources
+## 8base Resources
 
 ### Documentation
 This documentation site contains all the information you need to understand 8base capabilities and bring your projects to completion successfully.  We encourage you to follow the walkthroughs and quickstart guides for complete coverage. You can also take advantage of the search capabilities to find the information you are looking for.
@@ -19,16 +19,16 @@ For a more interactive learning experience, we encourage you to connect with our
 ### Support
 In the event of technical issues with the product, please reach out to our dedicated support team at [support@8base.com.](mailto:support@8base.com.) We are committed to providing you with the assistance you need to ensure a seamless experience with 8base.
 
-### Udemy bootcamp
+### Udemy Bootcamp
 A guided course on our backend capabilities is available at Udemy: [https://www.udemy.com/course/the-8base-developer-bootcamp-0-to-hero-course/](https://www.udemy.com/course/the-8base-developer-bootcamp-0-to-hero-course/)
 
-## External resources
+## External Resources
 The following are great documentation sites that cover technologies used within 8base, which might be useful.
 
 - [GraphQL Documentation](https://graphql.org/learn/)
 - [MUI Components](https://mui.com/material-ui/getting-started/supported-components/)
 - [Apollo client](https://www.apollographql.com/docs/react)
-- There are great tutorias for Javascript available online, but it is always useful to go [back to the basis](https://www.w3schools.com/js/) 
+- There are great tutorials for Javascript available online, but it is always useful to go [back to the basis](https://www.w3schools.com/js/) 
 
 
 


### PR DESCRIPTION
Fixed title casing on the Developer Resources help page. 